### PR TITLE
Added group nodes for table and child nodes of the column

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,6 @@ function App() {
     <>
       <ThemeProvider theme={theme}>
         <NavBar />
-        {/* <p>Server response: {tables}</p> */}
         <Flow tables={tables} />
       </ThemeProvider>
     </>

--- a/src/TableColumnsNode.tsx
+++ b/src/TableColumnsNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+// import { memo } from 'react';
 import { NodeProps } from 'reactflow';
 
 const CustomNode = ({ data }: NodeProps) => {
@@ -6,13 +6,11 @@ const CustomNode = ({ data }: NodeProps) => {
     <>
       <div className='tableName'>{data?.label}</div>
       {/* Map through data and handle cases of it being undefined */}
-      {data?.rows?.map((row, index) => (
-        <div className='table row' key={index}>{row}</div>
-      ))}
     </>
   );
 };
 
 CustomNode.displayName = 'CustomNode';
 
-export default memo(CustomNode);
+export default CustomNode;
+// export default memo(CustomNode);

--- a/src/TableNameNode.tsx
+++ b/src/TableNameNode.tsx
@@ -1,0 +1,32 @@
+// // import { memo } from 'react';
+// import { NodeProps } from 'reactflow';
+
+// const TableNameNode = ({ data }: NodeProps) => {
+//   return (
+//     <>
+//       <div className='tableName'>{data?.label}</div>
+//     </>
+//   );
+// };
+
+// TableNameNode.displayName = 'TableNameNode';
+
+// export default TableNameNode;
+// // export default memo(CustomNode);
+
+import { Node, NodeProps } from 'reactflow';
+ 
+type NodeData = {
+  data: {label: string};
+};
+ 
+type TableNameNode = Node<NodeData>;
+ 
+export default function TableNameNode({ data }: NodeProps<NodeData>):Node {
+    // const label = data.label;
+    return (
+      <>
+        <div>{data.label}</div>
+      </>
+    );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -62,6 +62,10 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+.react-flow__handle {
+  opacity: 0;
+}
+
 .flow-container {
   /* style={{ display: 'flex', width: '100vw', height: '90vh' }} */
   display: flex;


### PR DESCRIPTION
## Description:
This pull request implements subflows to display table names, with individual nodes to display column names in each table. The layout formula is slightly revised for the new subflow design.
## Changes Proposed:
- Replace individual nodes for each table with subflows and grouped nodes for each table
  - Use type: 'input' for subflow nodes
  - Currently using default node for column name nodes with handles hidden
  - draggable set to false for column name nodes
- Custom grid background
## Reasoning:
This set up will allow for connecting primary keys and foreign keys in the future
## Additional Notes:
We will need to set up custom nodes for column name nodes and perhap table name nodes in order to incorporate functional buttons (edit, delete, expand, etc)
## Testing Strategy:
Visual testing on localhost 5173
## Impact Assessment:
Most changes made to flow.tsx. Custom Node component code is started but not complete and not incorporated in any main code.
## Checklist:
[x] Column names are represented as individual nodes
[x] Columns are grouped into subflow group nodes
## Reviewer Request:
Kindly review the proposed test suite for route integration and provide feedback for any improvements or suggestions.
## Contributors
@margarethatch
@jennyouk
@JarodCrawford
@alexpalazzo