### PR TITLE
Jenny/column buttons finished

### DIFF
--- a/src/ColumnNameNode.tsx
+++ b/src/ColumnNameNode.tsx
@@ -1,26 +1,93 @@
 // import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
-import { IconButton, Typography, Box } from '@mui/material';
+import { IconButton, CheckIcon, Typography, Box } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteColumnButton from './DeleteColumnButton';
-// import React from 'react';
+import { useState } from 'react';
+import { Check } from '@mui/icons-material';
 
-const ColumnNameNode = ({ data }: {data: { label: string, parent: string }}) => {
+const ColumnNameNode = ({
+  data,
+}: {
+  data: { label: string; parent: string };
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedLabel, setEditedLabel] = useState(data.label);
 
   const handleEditClick = () => {
-    console.log('editing column', data.label, ' in table ', data.parent);
-  }
+    setIsEditing(true);
+  };
+
+  const handleInputChange = (e) => {
+    console.log(e.target.value);
+    setEditedLabel(e.target.value);
+  };
+
+  const handleCheckClick = async () => {
+
+    setIsEditing(false);
+    const response = await fetch('/api/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // This query is used to get the table names and columns from the database
+      // This is a graphQL query, not a SQL query
+      body: JSON.stringify({
+        query: `
+          mutation editColumn($newColumnName: String!, $columnName: String!, $tableName: String!){
+            editColumn( newColumnName: $newColumnName, columnName: $columnName, tableName: $tableName)
+          }
+        `,
+        variables: { newColumnName: editedLabel, columnName: data.label, tableName: data.parent},
+        //deleteColumnFromTable(tableName: ${data.parent}, columnName: ${data.label}): Table <-- if we want to get a string back instead of a table
+      }),
+    });
+
+    const final = await response.json();
+    if (final.errors) {
+      console.error(final.errors);
+      throw new Error('Error fetching tables');
+    }
+    console.log(final);
+
+    // console.log(editedLabel);
+
+    // Here, you can perform any actions you want with the edited label.
+    // For example, you can make an API call to update the label in your database.
+  };
 
   return (
-    <div className="column-name-node">
+    <div className='column-name-node'>
+      {/* These handles are currently transparent, set in the css */}
       <Handle type='target' position={Position.Left} />
       <Handle type='source' position={Position.Right} />
-      <Typography className='column-label' noWrap>{data.label}</Typography>
-      <Box sx={{ minWidth: 56}}>
-      <IconButton aria-label='edit' size='small' onClick={handleEditClick}>
-        <EditIcon fontSize='inherit' />
-      </IconButton>
-      <DeleteColumnButton data={data} />
+
+      {/* If editing: render text box with the label name as placeholder; Otherwise render the label name */}
+      {isEditing ? (
+        <input
+          type='text'
+          value={editedLabel}
+          onChange={handleInputChange}
+          placeholder={data.label}
+          className='column-input'
+        />
+      ) : (
+        <Typography className='column-label' noWrap>
+          {editedLabel}
+        </Typography>
+      )}
+      <Box sx={{ minWidth: 56 }}>
+
+        {/* If editing: render check button to save; Otherwise render the edit button*/}
+        {isEditing ? (
+          <IconButton aria-label='edit' size='small' onClick={handleCheckClick}>
+            <Check fontSize='inherit' />
+          </IconButton>
+        ) : (
+          <IconButton aria-label='edit' size='small' onClick={handleEditClick}>
+            <EditIcon fontSize='inherit' />
+          </IconButton>
+        )}
+        <DeleteColumnButton data={data} />
       </Box>
     </div>
   );

--- a/src/DeleteColumnButton.tsx
+++ b/src/DeleteColumnButton.tsx
@@ -35,6 +35,7 @@ const DeleteColumnButton = ({ data }: {data: { label: string, parent: string }})
       console.error(final.errors);
       throw new Error('Error fetching tables');
     }
+    console.log(final);
     return
   };
 

--- a/src/server/controller.ts
+++ b/src/server/controller.ts
@@ -171,6 +171,17 @@ export const resolvers = {
         console.error('Error in deleteColumn resolver: ', err);
         throw new Error('Server error');
       }
+    },
+    editColumn: async (_: any, { newColumnName, columnName, tableName }: { newColumnName: string, columnName: string, tableName: string }) => {
+      try {
+        // SQL to delete a table
+        await pool.query(`ALTER TABLE ${tableName}
+        RENAME COLUMN ${columnName} to ${newColumnName};`);
+        return `Column name changed to${newColumnName} from ${columnName} on ${tableName}.`;
+      } catch (err) {
+        console.error('Error in editColumn resolver: ', err);
+        throw new Error('Server error');
+      }
     }
   },
 };

--- a/src/server/typeDefs.ts
+++ b/src/server/typeDefs.ts
@@ -29,6 +29,7 @@ export const typeDefs = gql`
     editTableName(oldName: String!, newName: String!): String
     deleteTable(tableName: String!): String
     deleteColumn(tableName: String!, columnName: String!): String
+    editColumn(newColumnName: String!, columnName: String!, tableName: String!): String
   }
 `;
 


### PR DESCRIPTION
## Description:
This pull request completes functionality of edit column buttons
## Changes Proposed:
- fetch request to back end to change column name
- In edit mode, text field appears at column title and check button (save) takes place of edit button
## Reasoning:
Users should be able to alter the column names of their tables
## Additional Notes:
n/a
## Testing Strategy:
- postman testing
- browser testing
## Impact Assessment:
- testing is done directly to star wars db, so db has changes
## Checklist:
- [x] column edit button functionality
- [x] column title is changed
- [ ] delete column re-renders table node
## Reviewer Request:
Kindly review the proposed test suite for route integration and provide feedback for any improvements or suggestions.
## Contributors
@margarethatch
@jennyouk
@JarodCrawford
@alexpalazzo