### PR TITLE
remove ts-node and replace with tsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "eslint-plugin-react-refresh": "^0.4.5",
         "sass": "^1.70.0",
         "terser": "^5.27.0",
+        "tsx": "^4.7.0",
         "typescript": "^5.3.3",
         "vite": "^5.0.8"
       }
@@ -5322,6 +5323,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+      "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -7146,6 +7159,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -7829,6 +7851,25 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/tsx": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.0.tgz",
+      "integrity": "sha512-I+t79RYPlEYlHn9a+KzwrvEwhJg35h/1zHsLC2JXvhC2mdynMv6Zxzvhv5EMV6VF5qJlLlkSnMVvdZV3PSIGcg==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.19.10",
+        "get-tsconfig": "^4.7.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "sqlens",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite --host --port 5173 --open",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "start": "concurrently \"ts-node src/server/index.ts\" \"open http://localhost:3000\""
+    "start": "tsx src/server/index.ts"
   },
   "dependencies": {
     "@apollo/server": "^4.10.0",
@@ -51,6 +52,7 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "sass": "^1.70.0",
     "terser": "^5.27.0",
+    "tsx": "^4.7.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.8"
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,7 +5,7 @@ import { typeDefs } from './typeDefs';
 import pkg from 'pg';
 const { Pool } = pkg;
 import dotenv from 'dotenv';
-// import
+import open from 'open';
 
 dotenv.config();
 
@@ -51,6 +51,7 @@ async function startServer() {
     const PORT = process.env.PORT || 3000;
     app.listen(PORT, () => {
       console.log(`Server running on http://localhost:${PORT}`);
+      open(`http://localhost:${PORT}`);
     });
   }
 }


### PR DESCRIPTION
## Description:
This pull request replaces the ts-node dependency with tsx, an updated npm package that allows node to launch with typescript files.
## Changes Proposed:
- remove ts-node
- add tsx package
- import "open" to index.ts server file
- use open to open browser to 3000 after server starts up
- reintroduce "type":"module" to package.json
## Reasoning:
- fixes bug where browser will open to empty page (unable to load)
## Testing Strategy:
Local testing performed successfully 
## Checklist:
- [x] Browser opens after server starts up
## Reviewer Request:
Kindly review the proposed test suite for route integration and provide feedback for any improvements or suggestions.
## Contributors
@margarethatch
@jennyouk
@JarodCrawford
@alexpalazzo